### PR TITLE
Return null from GetHistory and Downloader

### DIFF
--- a/QuantConnect.IEX.Tests/IEXDataDownloaderTests.cs
+++ b/QuantConnect.IEX.Tests/IEXDataDownloaderTests.cs
@@ -41,9 +41,9 @@ namespace QuantConnect.Lean.DataSource.IEX.Tests
 
             var parameters = new DataDownloaderGetParameters(symbol, resolution, request.StartTimeUtc, request.EndTimeUtc, tickType);
 
-            var downloadResponse = _downloader.Get(parameters).ToList();
+            var downloadResponse = _downloader.Get(parameters)?.ToList();
 
-            Assert.IsEmpty(downloadResponse);
+            Assert.IsNull(downloadResponse);
         }
 
         [Explicit("This tests require a iexcloud.io api key")]
@@ -54,7 +54,7 @@ namespace QuantConnect.Lean.DataSource.IEX.Tests
 
             var parameters = new DataDownloaderGetParameters(symbol, resolution, request.StartTimeUtc, request.EndTimeUtc, tickType);
 
-            var downloadResponse = _downloader.Get(parameters).ToList();
+            var downloadResponse = _downloader.Get(parameters)?.ToList();
 
             Assert.IsNotEmpty(downloadResponse);
 

--- a/QuantConnect.IEX.Tests/IEXDataHistoryTests.cs
+++ b/QuantConnect.IEX.Tests/IEXDataHistoryTests.cs
@@ -136,8 +136,7 @@ namespace QuantConnect.Lean.DataSource.IEX.Tests
         {
             var slices = GetHistory(symbol, resolution, tickType, period);
 
-            Assert.IsEmpty(slices);
-            return;
+            Assert.IsNull(slices);
         }
 
         [Explicit("This tests require a iexcloud.io api key")]
@@ -228,7 +227,7 @@ namespace QuantConnect.Lean.DataSource.IEX.Tests
         {
             var requests = new[] { CreateHistoryRequest(symbol, resolution, tickType, period) };
 
-            var slices = iexDataProvider.GetHistory(requests, TimeZones.Utc).ToArray();
+            var slices = iexDataProvider.GetHistory(requests, TimeZones.Utc)?.ToArray();
             Log.Trace("Data points retrieved: " + iexDataProvider.DataPointCount);
             Log.Trace("tick Type: " + tickType);
             return slices;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Handle history provider returning null
  - This follows https://github.com/QuantConnect/Lean/pull/7804
- Handle data downloader provider returning null
  - This follows https://github.com/QuantConnect/Lean/pull/7812

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Maintain a uniform code format like in others repos.
Support several Data Sources.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Fixed old tests.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
