### PR TITLE
Historical data when symbol was restructured (renamed)

### DIFF
--- a/QuantConnect.IEX.Tests/IEXDataHistoryTests.cs
+++ b/QuantConnect.IEX.Tests/IEXDataHistoryTests.cs
@@ -160,6 +160,22 @@ namespace QuantConnect.Lean.DataSource.IEX.Tests
             Assert.That(slices, Is.Ordered.By("Time"));
         }
 
+        [Explicit("This tests require a iexcloud.io api key")]
+        [TestCase("GOOGL", Resolution.Daily, "2013/1/3", "2015/12/29", Description = "October 2, 2015. [GOOG -> GOOGL]")]
+        [TestCase("META", Resolution.Daily, "2020/1/3", "2023/12/29", Description = "October 28, 2021. [FB -> META]")]
+        public void GetAncientEquityHistoricalData(string ticker, Resolution resolution, DateTime startDate, DateTime endDate)
+        {
+            var symbol = Symbol.Create(ticker, SecurityType.Equity, Market.USA);
+
+            var request = CreateHistoryRequest(symbol, resolution, TickType.Trade, startDate, endDate);
+
+            var slices = iexDataProvider.GetHistory(new[] { request }, TimeZones.NewYork)?.ToList();
+
+            Assert.Greater(slices.Count, 1);
+            Assert.That(slices.First().Time.Date, Is.EqualTo(startDate));
+            Assert.That(slices.Last().Time.Date, Is.LessThanOrEqualTo(endDate));
+        }
+
         internal static void AssertTradeBar(Symbol expectedSymbol, Resolution resolution, BaseData baseData, Symbol actualSymbol = null)
         {
             if (actualSymbol != null)

--- a/QuantConnect.IEX/IEXDataProvider.cs
+++ b/QuantConnect.IEX/IEXDataProvider.cs
@@ -584,7 +584,8 @@ namespace QuantConnect.Lean.DataSource.IEX
                 return null;
             }
 
-            var ticker = request.Symbol.Value;
+            // Always obtain the most relevant ticker symbol based on the current time.
+            var ticker = SecurityIdentifier.Ticker(request.Symbol, DateTime.UtcNow);
             var startExchangeDateTime = ConvertTickTimeBySymbol(request.Symbol, request.StartTimeUtc);
             var endExchangeDateTime = ConvertTickTimeBySymbol(request.Symbol, request.EndTimeUtc);
 

--- a/QuantConnect.IEX/IEXDataProvider.cs
+++ b/QuantConnect.IEX/IEXDataProvider.cs
@@ -56,22 +56,22 @@ namespace QuantConnect.Lean.DataSource.IEX
         /// <summary>
         /// Flag indicating whether a warning about unsupported data types in user history should be suppressed to prevent spam.
         /// </summary>
-        private static bool _invalidHistoryDataTypeWarningFired;
+        private volatile bool _invalidHistoryDataTypeWarningFired;
 
         /// <summary>
         /// Indicates whether the warning for invalid <see cref="SecurityType"/> has been fired.
         /// </summary>
-        private bool _invalidSecurityTypeWarningFired;
+        private volatile bool _invalidSecurityTypeWarningFired;
 
         /// <summary>
         /// Indicates whether a warning for an invalid start time has been fired, where the start time is greater than or equal to the end time in UTC.
         /// </summary>
-        private bool _invalidStartTimeWarningFired;
+        private volatile bool _invalidStartTimeWarningFired;
 
         /// <summary>
         /// Indicates whether a warning for an invalid <see cref="Resolution"/> has been fired, where the resolution is neither daily nor minute-based.
         /// </summary>
-        private bool _invalidResolutionWarningFired;
+        private volatile bool _invalidResolutionWarningFired;
 
         /// <summary>
         /// Represents two clients: one for the trade channel and another for the top-of-book channel.
@@ -517,9 +517,9 @@ namespace QuantConnect.Lean.DataSource.IEX
                 {
                     if (!_invalidHistoryDataTypeWarningFired)
                     {
+                        _invalidHistoryDataTypeWarningFired = true;
                         Log.Error($"{nameof(IEXDataProvider)}.{nameof(GetHistory)}: Not supported data type - {request.DataType.Name}. " +
                             "Currently available support only for historical of type - TradeBar");
-                        _invalidHistoryDataTypeWarningFired = true;
                     }
                     continue;
                 }
@@ -528,8 +528,8 @@ namespace QuantConnect.Lean.DataSource.IEX
                 {
                     if (!_invalidSecurityTypeWarningFired)
                     {
-                        Log.Trace($"{nameof(IEXDataProvider)}.{nameof(GetHistory)}: Unsupported SecurityType '{request.Symbol.SecurityType}' for symbol '{request.Symbol}'");
                         _invalidSecurityTypeWarningFired = true;
+                        Log.Trace($"{nameof(IEXDataProvider)}.{nameof(GetHistory)}: Unsupported SecurityType '{request.Symbol.SecurityType}' for symbol '{request.Symbol}'");
                     }
                     continue;
                 }
@@ -538,8 +538,8 @@ namespace QuantConnect.Lean.DataSource.IEX
                 {
                     if (!_invalidStartTimeWarningFired)
                     {
-                        Log.Error($"{nameof(IEXDataProvider)}.{nameof(GetHistory)}: Error - The start date in the history request must come before the end date. No historical data will be returned.");
                         _invalidStartTimeWarningFired = true;
+                        Log.Error($"{nameof(IEXDataProvider)}.{nameof(GetHistory)}: Error - The start date in the history request must come before the end date. No historical data will be returned.");
                     }
                     continue;
                 }
@@ -548,8 +548,8 @@ namespace QuantConnect.Lean.DataSource.IEX
                 {
                     if (!_invalidResolutionWarningFired)
                     {
-                        Log.Error($"{nameof(IEXDataProvider)}.{nameof(GetHistory)}: History calls for IEX only support daily & minute resolution.");
                         _invalidResolutionWarningFired = true;
+                        Log.Error($"{nameof(IEXDataProvider)}.{nameof(GetHistory)}: History calls for IEX only support daily & minute resolution.");
                     }
                     continue;
                 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Currently, our data source supports both adjusted and unadjusted historical data for up to 15 years. However, there's a little twist: we're not always using the actual ticker name for historical data requests. Instead, we're sticking to the current ticker name, even if it had a different name in the past.

Here's the main point: we need to consistently use the actual ticker name, even if it had another name in the past, to ensure accuracy and reliability in our historical data.

Here's what I've done to address this:
- Implemented validation to ensure that the symbol always reflects the last trading ticker name based on `DateTime.Now`.
- Added the `volatile` keyword to prevent spamming flags for multi-threading interactions, enhancing the stability of our system.
- Refactored the **DataDownloader** to a more general format similar to other data sources, resulting in cleaner and more efficient code.
- **Fixed** a bug related to DateTime zones when creating a new Trade bar in history requests.

These changes should streamline our data handling process and improve the accuracy of historical data retrieval.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A
#### Related PR
- https://github.com/QuantConnect/Lean/pull/7826
- https://github.com/QuantConnect/Lean/pull/7845

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The motivation behind these changes is twofold. Firstly, by ensuring that our historical data requests accurately reflect the actual ticker names used during the corresponding trading periods, we aim to enhance the reliability and integrity of our data processing pipeline. This not only fosters trust in the data but also aligns with industry best practices for maintaining accurate historical records.

Secondly, adopting this approach assists users in creating flexible algorithms for their trading strategies. By providing historical data with consistent and accurate ticker names, we empower users to develop algorithms that adapt more seamlessly to changes in ticker names over time. This flexibility is crucial for implementing robust and adaptive trading strategies that can navigate evolving market conditions effectively.

Together, these enhancements not only improve the quality of our data but also contribute to the overall usability and effectiveness of our platform for traders and algorithm developers alike.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Test Case for ancient historical data.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
